### PR TITLE
Refactor how context is used

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ def gitRevision = { ->
 project.ext.gitRevision = gitRevision()
 
 group = 'paynefulapps.gocd.github.repo.task'
-version = '0.0.3-SNAPSHOT'
+version = '0.0.4-SNAPSHOT'
 
 // these values that go into plugin.xml
 // TODO: change these

--- a/src/main/java/paynefulapps/gocd/github/repo/task/RepoFetcher.java
+++ b/src/main/java/paynefulapps/gocd/github/repo/task/RepoFetcher.java
@@ -10,14 +10,17 @@ import java.net.http.HttpResponse;
 
 public class RepoFetcher {
     private final HttpClient client;
+    private Context pluginContext;
 
-    public RepoFetcher() {
+    public RepoFetcher(Context context) {
+        pluginContext = context;
+
         client = HttpClient.newBuilder()
                 .followRedirects(HttpClient.Redirect.ALWAYS)
                 .build();
     }
 
-    public Result fetchRepo(String repoUrl, String branchName, String authToken, Context context) {
+    public Result fetchRepo(String repoUrl, String branchName, String authToken) {
         try {
             File zippedRepo = downloadRepo(repoUrl, branchName, authToken);
             unzipRepo(zippedRepo);
@@ -42,7 +45,8 @@ public class RepoFetcher {
         HttpResponse<byte[]> response =  client.send(repoRequest, HttpResponse.BodyHandlers.ofByteArray());
         System.out.println("Status code: " + response.statusCode());
 
-        File zippedRepo = new File("./repo.zip");
+        String filePath = pluginContext.getWorkingDir() + "/repo.zip";
+        File zippedRepo = new File(filePath);
         FileOutputStream fileWriter = new FileOutputStream(zippedRepo);
         fileWriter.write(response.body());
         fileWriter.close();
@@ -52,7 +56,7 @@ public class RepoFetcher {
 
     public void unzipRepo(File zippedRepo) throws IOException {
         ProcessBuilder unzipCommandBuilder = new ProcessBuilder("unzip", zippedRepo.getAbsolutePath());
-        unzipCommandBuilder.directory(new File("./"));
+        unzipCommandBuilder.directory(new File(pluginContext.getWorkingDir()));
         unzipCommandBuilder.start();
     }
 }

--- a/src/main/java/paynefulapps/gocd/github/repo/task/RepoTaskExecutor.java
+++ b/src/main/java/paynefulapps/gocd/github/repo/task/RepoTaskExecutor.java
@@ -7,8 +7,8 @@ public class RepoTaskExecutor {
 
     public Result execute(paynefulapps.gocd.github.repo.task.TaskConfig taskConfig, Context context, JobConsoleLogger console) {
         try {
-            RepoFetcher repoFetcher = new RepoFetcher();
-            return repoFetcher.fetchRepo(taskConfig.getRepoUrl(), taskConfig.getBranchName(), taskConfig.getAuthToken(), context);
+            RepoFetcher repoFetcher = new RepoFetcher(context);
+            return repoFetcher.fetchRepo(taskConfig.getRepoUrl(), taskConfig.getBranchName(), taskConfig.getAuthToken());
         } catch (Exception e) {
             return new Result(false, "Failed to pull down repo from URL: " + taskConfig.getRepoUrl(), e);
         }

--- a/src/test/java/paynefulapps/gocd/github/repo/task/RepoFetcherTest.java
+++ b/src/test/java/paynefulapps/gocd/github/repo/task/RepoFetcherTest.java
@@ -30,7 +30,7 @@ public class RepoFetcherTest {
         String expectedRepoName = "./simple-image-server-main";
         String repoUrl = "https://github.com/YoungPhoenix09/simple-image-server";
         String branchName = "main";
-        
+
         repoFetcher.fetchRepo(
                 repoUrl,
                 branchName,

--- a/src/test/java/paynefulapps/gocd/github/repo/task/RepoFetcherTest.java
+++ b/src/test/java/paynefulapps/gocd/github/repo/task/RepoFetcherTest.java
@@ -14,9 +14,7 @@ import java.util.Properties;
 import static org.junit.Assert.assertTrue;
 
 public class RepoFetcherTest {
-    private final RepoFetcher repoFetcher = new RepoFetcher();
-    private final String repoUrl = "https://github.com/YoungPhoenix09/simple-image-server";
-    private final String branchName = "main";
+    private final RepoFetcher repoFetcher = new RepoFetcher(createContext());
     private String authToken = "";
 
     @Before
@@ -30,15 +28,13 @@ public class RepoFetcherTest {
     @Test
     public void repoIsFetchedAsZip() {
         String expectedRepoName = "./simple-image-server-main";
-        Map<String,Object> contextMap = new HashMap<>();
-        contextMap.put("workingDirectory", "./");
-        Context context = new Context(contextMap);
-
+        String repoUrl = "https://github.com/YoungPhoenix09/simple-image-server";
+        String branchName = "main";
+        
         repoFetcher.fetchRepo(
-            repoUrl,
-            branchName,
-            authToken,
-            context
+                repoUrl,
+                branchName,
+            authToken
         );
 
         File repoDir = new File(expectedRepoName);
@@ -56,5 +52,12 @@ public class RepoFetcherTest {
             deleteProcess.command("rm", "-rf", repoPath);
             deleteProcess.start();
         }
+    }
+
+    private Context createContext() {
+        Map<String,Object> contextMap = new HashMap<>();
+        contextMap.put("workingDirectory", "./");
+
+        return new Context(contextMap);
     }
 }


### PR DESCRIPTION
The previous change only allowed the context to be passed in, but the working directory was not incorporated into how the repo was saved. This change fixes that.